### PR TITLE
Add score tracking with SDL_ttf-rendered overlay

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -52,10 +52,12 @@ void Board::Swap(const IVec2 & a, const IVec2 & b)
     std::swap(cells_[Index(a)], cells_[Index(b)]);
 }
 
-bool Board::FindMatches(std::vector<bool> & out_mask) const
+bool Board::FindMatches(std::vector<bool> & out_mask, int & out_groups, int & out_cells) const
 {
     out_mask.assign(kWidth * kHeight, false);
-    return FindMatchesMask(out_mask);
+    out_groups = 0;
+    out_cells = 0;
+    return FindMatchesMask(out_mask, out_groups, out_cells);
 }
 
 int Board::CollapseAndRefillPlanned(const std::vector<bool> & mask,
@@ -107,7 +109,7 @@ int Board::Index(const IVec2 & p) const
     return p.y * kWidth + p.x;
 }
 
-bool Board::FindMatchesMask(std::vector<bool> & out_mask) const
+bool Board::FindMatchesMask(std::vector<bool> & out_mask, int & out_groups, int & out_cells) const
 {
     bool any = false;
 
@@ -127,9 +129,15 @@ bool Board::FindMatchesMask(std::vector<bool> & out_mask) const
                 if (run_len >= 3)
                 {
                     any = true;
+                    ++out_groups;
                     for (int k = 0; k < run_len; ++k)
                     {
-                        out_mask[Index({x - 1 - k, y})] = true;
+                        const int idx = Index({x - 1 - k, y});
+                        if (!out_mask[idx])
+                        {
+                            out_mask[idx] = true;
+                            ++out_cells;
+                        }
                     }
                 }
                 run_len = 1;
@@ -157,9 +165,15 @@ bool Board::FindMatchesMask(std::vector<bool> & out_mask) const
                 if (run_len >= 3)
                 {
                     any = true;
+                    ++out_groups;
                     for (int k = 0; k < run_len; ++k)
                     {
-                        out_mask[Index({x, y - 1 - k})] = true;
+                        const int idx = Index({x, y - 1 - k});
+                        if (!out_mask[idx])
+                        {
+                            out_mask[idx] = true;
+                            ++out_cells;
+                        }
                     }
                 }
                 run_len = 1;

--- a/src/board.h
+++ b/src/board.h
@@ -37,8 +37,10 @@ public:
     // Low-level swap (used by the state machine).
     void Swap(const IVec2 & a, const IVec2 & b);
 
-    // Public match finding.
-    bool FindMatches(std::vector<bool> & out_mask) const;
+    // Public match finding. Returns true if any matches were found and
+    // fills out_mask with matched cells. Additionally outputs the number
+    // of distinct match groups and total matched cells for scoring.
+    bool FindMatches(std::vector<bool> & out_mask, int & out_groups, int & out_cells) const;
 
     // Collapse columns and refill with new candies.
     // Mutates the board to the post-collapse state and returns planned tile moves and spawns.
@@ -53,7 +55,7 @@ private:
     int Index(const IVec2 & p) const;
 
     // Internal helpers
-    bool FindMatchesMask(std::vector<bool> & out_mask) const;
+    bool FindMatchesMask(std::vector<bool> & out_mask, int & out_groups, int & out_cells) const;
     CellType RandomCandy();
     CellType RandomCandyAvoiding(int x, int y);
 };

--- a/src/game.h
+++ b/src/game.h
@@ -24,6 +24,8 @@ private:
     AnimationSystem anims_;
     VisualBoard vboard_;
 
+    int score_ {0};
+
     BoardLayout layout_{};
 
     enum class Phase

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -3,8 +3,10 @@
 #include "visuals.h"
 
 #include <SDL.h>
+#include <SDL_ttf.h>
 #include <vector>
 #include <optional>
+#include <string>
 
 struct BoardLayout
 {
@@ -19,7 +21,8 @@ struct BoardLayout
 class Renderer
 {
 public:
-    explicit Renderer(SDL_Renderer * r) : r_(r) {}
+    explicit Renderer(SDL_Renderer * r);
+    ~Renderer();
 
     BoardLayout ComputeLayout(int window_w, int window_h, int gap_px = 4) const;
 
@@ -34,8 +37,11 @@ public:
                    const std::optional<IVec2> & secondary = std::nullopt,
                    float pulse_t = 0.0f) const;
 
+    void DrawScore(int score) const;
+
 private:
     SDL_Renderer * r_ { nullptr };
+    TTF_Font * font_ { nullptr };
 
     void SetColorForCell(CellType type, uint8_t alpha) const;
 


### PR DESCRIPTION
## Summary
- count matched tiles and match groups to produce score with per-cascade multiplier
- render score using SDL_ttf in a framed overlay
- rely on external SDL_ttf setup without altering CMake and fix highlight thickness

## Testing
- `cmake -S . -B build`
- `cmake --build build -j 4` *(fails: SDL_ttf.h: No such file or directory)*
- `g++ -c src/board.cpp -std=c++20`


------
https://chatgpt.com/codex/tasks/task_e_689cc29d82dc832fb85a8c80e424811f